### PR TITLE
Fix hamster wheel block entity ID

### DIFF
--- a/src/main/java/com/starfish_studios/hamsters/registry/HamstersBlockEntities.java
+++ b/src/main/java/com/starfish_studios/hamsters/registry/HamstersBlockEntities.java
@@ -15,7 +15,7 @@ public class HamstersBlockEntities {
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_TYPES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, MOD_ID);
 
     public static final RegistryObject<BlockEntityType<HamsterWheelBlockEntity>> HAMSTER_WHEEL = BLOCK_ENTITY_TYPES.register(
-            "hamsters",
+            "hamster_wheel",
             () -> BlockEntityType.Builder.of(HamsterWheelBlockEntity::new, HamstersBlocks.HAMSTER_WHEEL.get()).build(null)
     );
 


### PR DESCRIPTION
## Summary
- use `hamster_wheel` as the block entity registry ID instead of `hamsters`

## Testing
- `./gradlew tasks --all`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6854d91e4068833189d8c5d0bd730b81